### PR TITLE
ci: use secrets npm token vs creating npmrc

### DIFF
--- a/.changeset/soft-buckets-relate.md
+++ b/.changeset/soft-buckets-relate.md
@@ -1,0 +1,5 @@
+---
+'@lglab/react-qr-code': patch
+---
+
+use secrets npm token vs creating npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,6 @@ jobs:
         with:
           version: 10
 
-      - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-
       - name: Install Dependencies
         run: pnpm install
 
@@ -41,3 +38,4 @@ jobs:
           publish: pnpm ci:publish --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced security and streamlined our package publishing process by switching from a file-based to an environment variable-based token configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->