### PR TITLE
fix(ui): center Hero block

### DIFF
--- a/apps/docs/src/components/hero.tsx
+++ b/apps/docs/src/components/hero.tsx
@@ -7,7 +7,7 @@ import { TypographyLead } from './ui/typography'
 
 export const Hero = () => {
   return (
-    <section className='py-8 mb-5'>
+    <section className='py-8 mb-5 mx-auto'>
       <div className='container text-center'>
         <div className='mx-auto flex max-w-5xl flex-col gap-6'>
           <h1 className='text-3xl font-semibold lg:text-6xl'>


### PR DESCRIPTION
## Issue

On bigger screens (> 1880px) the Hero block is not aligned correctly.

## Before

<img width="1058" height="712" alt="image" src="https://github.com/user-attachments/assets/8c721435-9e19-4ed5-8fb1-18b8f6cb4d93" />

## After

<img width="1057" height="717" alt="image" src="https://github.com/user-attachments/assets/840f4c43-663b-4e0d-86fd-ddef2cc3978e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted hero section horizontal alignment on documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->