### PR TITLE
fix(ci): pass --no-git-checks to publish only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
-          publish: pnpm ci:publish --no-git-checks
+          publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch:packages": "pnpm --filter \"./packages/**\" run build --watch",
     "watch:docs": "pnpm --filter \"./apps/docs/**\" run dev",
     "build:lib": "pnpm --filter \"./packages/**\" run build",
-    "ci:publish": "pnpm build:lib && pnpm publish -r && pnpm changeset tag",
+    "ci:publish": "pnpm build:lib && pnpm publish -r --no-git-checks && pnpm changeset tag",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
pnpm forwarded trailing flags to changeset tag, which rejected them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process configuration to streamline the publishing workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LGLabGreg/react-qr-code/pull/531)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->