### PR TITLE
chore: drop minimumReleaseAgeExclude entries for next 16.3.0

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,18 +5,6 @@ packages:
 allowBuilds:
   sharp: true
 
-minimumReleaseAgeExclude:
-  - '@next/env@16.3.0'
-  - '@next/swc-darwin-arm64@16.3.0'
-  - '@next/swc-darwin-x64@16.3.0'
-  - '@next/swc-linux-arm64-gnu@16.3.0'
-  - '@next/swc-linux-arm64-musl@16.3.0'
-  - '@next/swc-linux-x64-gnu@16.3.0'
-  - '@next/swc-linux-x64-musl@16.3.0'
-  - '@next/swc-win32-arm64-msvc@16.3.0'
-  - '@next/swc-win32-x64-msvc@16.3.0'
-  - next@16.3.0
-
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
next@16.3.0 published 2026-08-03 and now clears pnpm's release-age gate on its own, so the exact-version waivers are dead weight. pnpm install leaves the lockfile untouched and does not re-add them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace package installation configuration by removing an explicit release-age exclusion list.
  * Existing build settings remain enabled for supported packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->